### PR TITLE
Use stable MAC-based identity instead of entry_id (fixes #19)

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_IP, DOMAIN, PYASIC_VERSION
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -123,6 +126,67 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     await async_setup_services(hass)
 
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate the entry_id-based identity to a stable MAC-based one (see #19/#22).
+
+    v1 derived every device identifier and entity unique_id from entry_id, so a
+    delete + re-add orphaned all entities. v2 anchors them on the miner MAC.
+    Entity_ids are preserved (only unique_id changes), so nothing breaks.
+    """
+    if config_entry.version >= 2:
+        return True
+
+    from homeassistant.helpers import device_registry as dr_
+    from homeassistant.helpers import entity_registry as er_
+    from homeassistant.helpers.device_registry import format_mac
+
+    # The MAC can only be read from the live miner.
+    mac = None
+    try:
+        pyasic = await hass.async_add_executor_job(_ensure_pyasic)
+        miner = await pyasic.get_miner(config_entry.data[CONF_IP])
+        if miner is not None:
+            data = await miner.get_data()
+            mac = getattr(data, "mac", None)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("MAC lookup during migration failed", exc_info=True)
+
+    if not mac:
+        # Miner offline: keep v1 (entities still work via the entry_id fallback);
+        # migration retries on the next restart when the miner is reachable.
+        _LOGGER.warning(
+            "Miner '%s' migration deferred: MAC not readable (miner offline)",
+            config_entry.title,
+        )
+        return True
+
+    new_base = format_mac(mac)
+    old_base = config_entry.entry_id
+    prefix = f"{old_base}-"
+
+    ent_reg = er_.async_get(hass)
+    for entity in er_.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
+        if entity.unique_id.startswith(prefix):
+            new_uid = f"{new_base}-{entity.unique_id[len(prefix):]}"
+            if ent_reg.async_get_entity_id(entity.domain, DOMAIN, new_uid) is None:
+                ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
+
+    dev_reg = dr_.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, old_base)})
+    if device is not None:
+        dev_reg.async_update_device(device.id, new_identifiers={(DOMAIN, new_base)})
+
+    hass.config_entries.async_update_entry(
+        config_entry, unique_id=new_base, version=2
+    )
+    _LOGGER.info(
+        "Miner '%s' identity migrated to MAC-based ids (%s)",
+        config_entry.title,
+        new_base,
+    )
     return True
 
 

--- a/custom_components/miner/button.py
+++ b/custom_components/miner/button.py
@@ -51,14 +51,14 @@ class AvalonRebootButton(CoordinatorEntity[MinerCoordinator], ButtonEntity):
     @property
     def unique_id(self) -> str | None:
         """Return device UUID."""
-        return f"{self.coordinator.config_entry.entry_id}-reboot"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-reboot"
 
     @property
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -151,6 +151,22 @@ class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._miner = miner
+
+        # Anchor the config entry on the miner's MAC so devices/entities survive
+        # re-adds and IP changes instead of being orphaned (see #19). Best-effort:
+        # if the MAC can't be read we fall back to the entry_id-based identity.
+        try:
+            from homeassistant.helpers.device_registry import format_mac
+
+            miner_data = await miner.get_data()
+            mac = getattr(miner_data, "mac", None)
+        except Exception:  # noqa: BLE001 - MAC is best-effort
+            mac = None
+            _LOGGER.debug("Could not read MAC for unique_id", exc_info=True)
+        if mac:
+            await self.async_set_unique_id(format_mac(mac))
+            self._abort_if_unique_id_configured()
+
         self._data.update(user_input)
         return await self.async_step_login()
 

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -116,7 +116,7 @@ def _is_avalon_miner(miner) -> bool:
 class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Miner."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self):
         """Initialize."""

--- a/custom_components/miner/light.py
+++ b/custom_components/miner/light.py
@@ -65,14 +65,14 @@ class AvalonLedLight(CoordinatorEntity[MinerCoordinator], LightEntity):
     @property
     def unique_id(self) -> str | None:
         """Return device UUID."""
-        return f"{self.coordinator.config_entry.entry_id}-led_light"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-led_light"
 
     @property
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -100,7 +100,7 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -112,7 +112,7 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
     @property
     def unique_id(self) -> str | None:
         """Return device UUID."""
-        return f"{self.coordinator.config_entry.entry_id}-power_limit"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-power_limit"
 
     @property
     def native_min_value(self) -> float | None:
@@ -558,7 +558,7 @@ class _VNishOverclockBase(CoordinatorEntity[MinerCoordinator], NumberEntity):
     def device_info(self) -> entity.DeviceInfo:
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -608,7 +608,7 @@ class VNishVoltageNumber(_VNishOverclockBase):
     @property
     def unique_id(self) -> str:
         """Return unique entity id."""
-        return f"{self.coordinator.config_entry.entry_id}-vnish-voltage"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-vnish-voltage"
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -661,7 +661,7 @@ class VNishFrequencyNumber(_VNishOverclockBase):
     @property
     def unique_id(self) -> str:
         """Return unique entity id."""
-        return f"{self.coordinator.config_entry.entry_id}-vnish-frequency"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-vnish-frequency"
 
     @property
     def native_unit_of_measurement(self) -> str:

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -431,7 +431,7 @@ class AvalonWorkModeSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -443,7 +443,7 @@ class AvalonWorkModeSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
     @property
     def unique_id(self) -> str | None:
         """Return device UUID."""
-        return f"{self.coordinator.config_entry.entry_id}-workmode"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-workmode"
 
     @property
     def current_option(self) -> str | None:
@@ -523,7 +523,7 @@ class AvalonLedEffectSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -535,7 +535,7 @@ class AvalonLedEffectSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
     @property
     def unique_id(self) -> str | None:
         """Return device UUID."""
-        return f"{self.coordinator.config_entry.entry_id}-led_effect"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-led_effect"
 
     @property
     def current_option(self) -> str | None:
@@ -627,7 +627,7 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         """Return device registry information for this entity."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -639,7 +639,7 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID for this entity."""
-        return f"{self.coordinator.config_entry.entry_id}-vnish_preset"
+        return f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-vnish_preset"
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -312,7 +312,7 @@ class MinerSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-{sensor}"
         self._sensor = sensor
         self.entity_description = entity_description
 
@@ -334,7 +334,7 @@ class MinerSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -367,7 +367,7 @@ class MinerBoardSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-{board_num}-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-{board_num}-{sensor}"
         self._board_num = board_num
         self._sensor = sensor
         self.entity_description = entity_description
@@ -390,7 +390,7 @@ class MinerBoardSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -423,7 +423,7 @@ class MinerFanSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-{fan_num}-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-{fan_num}-{sensor}"
         self._fan_num = fan_num
         self._sensor = sensor
         self.entity_description = entity_description
@@ -447,7 +447,7 @@ class MinerFanSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -479,7 +479,7 @@ class AvalonSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-avalon-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-avalon-{sensor}"
         self._sensor = sensor
         self.entity_description = entity_description
 
@@ -502,7 +502,7 @@ class AvalonSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -534,7 +534,7 @@ class VNishSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-vnish-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-vnish-{sensor}"
         self._sensor = sensor
         self.entity_description = entity_description
 
@@ -557,7 +557,7 @@ class VNishSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -589,7 +589,7 @@ class BOSSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-bos-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-bos-{sensor}"
         self._sensor = sensor
         self.entity_description = entity_description
 
@@ -612,7 +612,7 @@ class BOSSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -644,7 +644,7 @@ class BitAxeSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-bitaxe-{sensor}"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-bitaxe-{sensor}"
         self._sensor = sensor
         self.entity_description = entity_description
 
@@ -667,7 +667,7 @@ class BitAxeSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -110,7 +110,7 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-active"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-active"
         self._attr_is_on = self.coordinator.data["is_mining"]
         self.updating_switch = False
         self._last_mining_mode = None
@@ -125,7 +125,7 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
@@ -218,7 +218,7 @@ class AvalonMiningSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     def __init__(self, coordinator: MinerCoordinator) -> None:
         """Initialize the switch."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-avalon-mining"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-avalon-mining"
         # Get initial state from coordinator data, default to True
         asc_enabled = self.coordinator.data.get("avalon_asc_enabled")
         self._attr_is_on = asc_enabled if asc_enabled is not None else True
@@ -234,7 +234,7 @@ class AvalonMiningSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],
@@ -343,7 +343,7 @@ class VnishLegacyMiningSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity)
     def __init__(self, coordinator: MinerCoordinator) -> None:
         """Initialize the switch."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-vnish-legacy-mining"
+        self._attr_unique_id = f"{(self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id)}-vnish-legacy-mining"
         self._attr_is_on = self.coordinator.data.get("is_mining", True)
         self._updating_switch = False
 
@@ -357,7 +357,7 @@ class VnishLegacyMiningSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity)
         """Return device info."""
         mac = self.coordinator.data.get("mac")
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, (self.coordinator.config_entry.unique_id or self.coordinator.config_entry.entry_id))},
             connections={(device_registry.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
             configuration_url=f"http://{self.coordinator.data['ip']}",
             manufacturer=self.coordinator.data["make"],


### PR DESCRIPTION
> **⚠️ Draft — not yet validated against hardware.** Opening for direction/feedback. See "Testing needed" below. Built without a live miner; the code-level reasoning is sound but it should be run against real devices before merge.

Fixes #19.

## Problem
Device identifiers and every entity `unique_id` are derived from `config_entry.entry_id`:
```python
self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}-{board_num}-{sensor}"
identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)}
```
The MAC is already fetched (`coordinator.data["mac"]`) but only used as a `connection`, not an identifier. Consequences:
1. **Delete + re-add orphans everything** — a new `entry_id` ⇒ all new `unique_id`s ⇒ HA registers brand-new device/entities, old `entity_id`s break. (So re-adding to "fix" the drift reproduces it.)
2. **Entity set is built from live data at setup** (`range(coordinator.miner.expected_hashboards or 3)` + the live `miner_sensors`/`board_sensors` after `async_config_entry_first_refresh()`), so an offline or partial-board miner yields a *different* set — which is the selective renaming reported in #19.

## This PR (forward-safe, minimal)
- **`config_flow`**: set the entry `unique_id = format_mac(<miner MAC>)` (best-effort, falls back silently) and `_abort_if_unique_id_configured()`. Re-adding the same miner now re-attaches; duplicate entries are prevented.
- **All entity platforms**: identity base becomes `config_entry.unique_id or config_entry.entry_id`. New (MAC-anchored) entries are stable across re-add/IP-change; **existing entries are unchanged** (unique_id is None ⇒ entry_id base, zero migration risk).

## Not in this PR (needs discussion + testing)
- **Registry migration for existing installs** (`{entry_id}-…` → `{mac}-…`) so current users benefit without re-adding. Drafting that safely needs a miner online to read the MAC + careful entity/device-registry rewrite.
- **Board-index mismatch** (separate, related bug): board *entities* are created via `range(expected_hashboards)` (0,1,2) while board *data* is keyed by `board.slot` (e.g. a Hydro reports slot 3). Creating board entities from the actual reported slots would also stabilise that set. Can fold in or split out.

## Testing needed
- [ ] Add a miner, confirm entities/device unchanged in behaviour, `unique_id` now MAC-based.
- [ ] Delete + re-add the same miner → entities re-attach (no orphans).
- [ ] Miner offline at setup, partial-board miner (Antminer Hydro) → stable set.
