### PR TITLE
Bump pinned pyasic 0.78.0 → 0.78.12 (fixes VNish get_data, #19)

### DIFF
--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -24,7 +24,7 @@ SERVICE_SET_WORK_MODE = "set_work_mode"
 # pyasic 0.78.0 - works with Avalon Nano 3s and pydantic>=2.11.0 (compatible with HA)
 # Note: Whatsminer users may need to manually enable API via WhatsMinerTool
 # Python 3.14 requires pydantic patch (applied in patch.py)
-PYASIC_VERSION = "0.78.0"
+PYASIC_VERSION = "0.78.12"
 
 TERA_HASH_PER_SECOND = "TH/s"
 JOULES_PER_TERA_HASH = "J/TH"


### PR DESCRIPTION
Bumps the pinned `PYASIC_VERSION` from `0.78.0` to `0.78.12`.

**Why:** pyasic 0.78.0 fails to read **VNish** miners — `get_data` raises `APIError: Failed to call config ... while getting data` (so VNish miners get no data at all) — and has flaky Braiins/BOS auto-detection. **0.78.12 fixes the VNish path** and stays API-compatible with the coordinator's data model (unlike 0.79.x, which may change it).

**Validated** on a live install: an `S19 Pro Hydro` (VNish) and an `S19k Pro No PIC` (Braiins/BOS) both read correctly with 0.78.12 (VNish: 146 TH/s incl. all 4 hashboards; BOS: ~27 TH/s) where 0.78.0 returned the `Failed to call config` error.

This is the underlying root cause of #19 (entities "renamed"/missing was a downstream symptom of the integration never getting clean data from these miners).

Note: pyasic should ideally be installed `--no-deps` to avoid pulling a newer `cryptography` that conflicts with HA core's pin — see separate PR.
