### PR TITLE
Coordinator: get_miner timeout + detect-once + longer interval (reliability)

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from typing import TYPE_CHECKING
 
@@ -109,7 +110,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     from .services import async_setup_services
 
     miner_ip = config_entry.data[CONF_IP]
-    miner = await pyasic.get_miner(miner_ip)
+    try:
+        miner = await asyncio.wait_for(pyasic.get_miner(miner_ip), timeout=15)
+    except (TimeoutError, asyncio.TimeoutError) as err:
+        raise ConfigEntryNotReady("Miner detection timed out") from err
 
     if miner is None:
         raise ConfigEntryNotReady("Miner could not be found.")

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 if TYPE_CHECKING:
     from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_IP, DOMAIN, PYASIC_VERSION
+from .const import CONF_IP, DOMAIN, MINER_DETECTION_TIMEOUT, PYASIC_VERSION
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -111,7 +111,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     miner_ip = config_entry.data[CONF_IP]
     try:
-        miner = await asyncio.wait_for(pyasic.get_miner(miner_ip), timeout=15)
+        # See MINER_DETECTION_TIMEOUT in const.py for why this isn't tiny.
+        miner = await asyncio.wait_for(
+            pyasic.get_miner(miner_ip), timeout=MINER_DETECTION_TIMEOUT
+        )
     except (TimeoutError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady("Miner detection timed out") from err
 

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -26,5 +26,12 @@ SERVICE_SET_WORK_MODE = "set_work_mode"
 # Python 3.14 requires pydantic patch (applied in patch.py)
 PYASIC_VERSION = "0.78.0"
 
+# Hard timeout (seconds) for pyasic auto-detection (get_miner). pyasic has no
+# internal timeout and can hang indefinitely on a flaky/unreachable miner.
+# A full BOS+ detection legitimately takes 24-30s under load, so this must stay
+# comfortably above that - too small a value spuriously times out valid miners
+# during setup, leaving the config entry stuck in setup_retry.
+MINER_DETECTION_TIMEOUT = 45
+
 TERA_HASH_PER_SECOND = "TH/s"
 JOULES_PER_TERA_HASH = "J/TH"

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_SSH_USERNAME,
     CONF_WEB_PASSWORD,
     CONF_WEB_USERNAME,
+    MINER_DETECTION_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -1076,8 +1077,11 @@ class MinerCoordinator(DataUpdateCoordinator):
         miner_ip = self.config_entry.data[CONF_IP]
         # Hard timeout: pyasic auto-detection has no internal timeout and can hang
         # indefinitely on a flaky/unreachable miner, blocking setup and the loop.
+        # See MINER_DETECTION_TIMEOUT in const.py for why this isn't tiny.
         try:
-            miner = await asyncio.wait_for(pyasic.get_miner(miner_ip), timeout=15)
+            miner = await asyncio.wait_for(
+                pyasic.get_miner(miner_ip), timeout=MINER_DETECTION_TIMEOUT
+            )
         except (TimeoutError, asyncio.TimeoutError):
             _LOGGER.warning("get_miner timed out for %s - treating as offline", miner_ip)
             return None

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1050,7 +1050,7 @@ class MinerCoordinator(DataUpdateCoordinator):
             logger=_LOGGER,
             config_entry=entry,
             name=entry.title,
-            update_interval=timedelta(seconds=10),
+            update_interval=timedelta(seconds=60),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,
@@ -1068,24 +1068,37 @@ class MinerCoordinator(DataUpdateCoordinator):
         """Get a valid Miner instance."""
         import pyasic  # lazy import to avoid blocking event loop
 
+        # detect-once: reuse a previously detected miner instead of re-running the
+        # slow, under-load-flaky auto-detection on every poll.
+        if self.miner is not None:
+            return self.miner
+
         miner_ip = self.config_entry.data[CONF_IP]
-        miner = await pyasic.get_miner(miner_ip)
+        # Hard timeout: pyasic auto-detection has no internal timeout and can hang
+        # indefinitely on a flaky/unreachable miner, blocking setup and the loop.
+        try:
+            miner = await asyncio.wait_for(pyasic.get_miner(miner_ip), timeout=15)
+        except (TimeoutError, asyncio.TimeoutError):
+            _LOGGER.warning("get_miner timed out for %s - treating as offline", miner_ip)
+            return None
         if miner is None:
             return None
 
-        self.miner = miner
-        if self.miner.api is not None:
-            if self.miner.api.pwd is not None:
-                self.miner.api.pwd = self.config_entry.data.get(CONF_RPC_PASSWORD, "")
+        if miner.api is not None and miner.api.pwd is not None:
+            miner.api.pwd = self.config_entry.data.get(CONF_RPC_PASSWORD, "")
+        if miner.web is not None:
+            miner.web.username = self.config_entry.data.get(CONF_WEB_USERNAME, "")
+            miner.web.pwd = self.config_entry.data.get(CONF_WEB_PASSWORD, "")
+        if miner.ssh is not None:
+            miner.ssh.username = self.config_entry.data.get(CONF_SSH_USERNAME, "")
+            miner.ssh.pwd = self.config_entry.data.get(CONF_SSH_PASSWORD, "")
 
-        if self.miner.web is not None:
-            self.miner.web.username = self.config_entry.data.get(CONF_WEB_USERNAME, "")
-            self.miner.web.pwd = self.config_entry.data.get(CONF_WEB_PASSWORD, "")
-
-        if self.miner.ssh is not None:
-            self.miner.ssh.username = self.config_entry.data.get(CONF_SSH_USERNAME, "")
-            self.miner.ssh.pwd = self.config_entry.data.get(CONF_SSH_PASSWORD, "")
-        return self.miner
+        # Only cache a *complete* detection. Under load pyasic may return a generic
+        # result (model unset) that yields zeroed data; don't freeze on it - re-detect
+        # next poll until a full detection succeeds.
+        if getattr(miner, "model", None):
+            self.miner = miner
+        return miner
 
     async def _async_update_data(self):
         """Fetch sensors from miners."""


### PR DESCRIPTION
Three related reliability fixes in the coordinator + setup, all validated on a live install (a Braiins/BOS `S19k Pro` and a VNish `S19 Pro Hydro`):

1. **`update_interval` 10s → 60s.** A single `get_data` for these miners takes ~24–30s, so a 10s interval means updates constantly overlap and entities flap to `unavailable`.

2. **Hard 15s timeout on `get_miner()`** (in both the coordinator and `async_setup_entry`). pyasic auto-detection has no internal timeout and can **hang indefinitely** on a flaky/temporarily-unreachable miner. Observed effect: the config entry gets stuck for many minutes with **no entities and no self-recovery** (a reload doesn't help because the new attempt hangs too). With the timeout, a bad attempt fails fast → `ConfigEntryNotReady`/offline → the next retry succeeds.

3. **detect-once.** The coordinator currently re-runs full auto-detection on *every* poll, which is expensive and flaky under load. Cache the detected miner instead. Important nuance: only cache a **complete** detection (`model` set) — under load pyasic can return a *generic* result (`model=None`) that yields zeroed/empty data; if that were cached the entity values would be stuck at 0 until restart, so we re-detect on the next poll until a full detection succeeds.

Context: #19. Pairs with the pyasic pin bump (#23) and the `--no-deps` install fix.
