### PR TITLE
Install pyasic with --no-deps (avoid cryptography conflict with HA core)

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -65,7 +65,7 @@ def _ensure_pyasic():
     # Need to install/reinstall
     from .patch import install_package
 
-    install_package(f"pyasic=={PYASIC_VERSION}", force_reinstall=True)
+    install_package(f"pyasic=={PYASIC_VERSION}", force_reinstall=True, no_deps=True)
 
     # Clear any cached broken imports
     for mod_name in list(sys.modules.keys()):

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -58,7 +58,7 @@ def _ensure_pyasic():
     except (ImportError, Exception):
         from .patch import install_package
 
-        install_package(f"pyasic=={PYASIC_VERSION}")
+        install_package(f"pyasic=={PYASIC_VERSION}", no_deps=True)
         import pyasic as _pyasic
 
     pyasic = _pyasic

--- a/custom_components/miner/patch.py
+++ b/custom_components/miner/patch.py
@@ -26,6 +26,7 @@ def install_package(
     constraints: str | None = None,
     timeout: int | None = None,
     force_reinstall: bool = False,
+    no_deps: bool = False,
 ) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
 
@@ -55,6 +56,8 @@ def install_package(
         args.append("--upgrade")
     if force_reinstall:
         args.append("--reinstall")
+    if no_deps:
+        args.append("--no-deps")
     if constraints is not None:
         args += ["--constraint", constraints]
     if target:


### PR DESCRIPTION
`install_package()` reinstalls pyasic with **its dependencies + `--upgrade`**, which can pull a newer `cryptography` (observed: 48.x) than Home Assistant core pins (`cryptography==47.0.0`). Installing that into HA's environment can **break HA core** (pip even warns: `homeassistant X.Y requires cryptography==47.0.0, but you have cryptography 48.0.0 which is incompatible`).

pyasic's own declared deps (`betterproto`, `grpcio`) are already in the integration's `manifest.json` `requirements`, and the remaining transitive deps (`pydantic`, `aiohttp`, …) are provided by HA core. So installing **pyasic `--no-deps`** is sufficient and avoids touching core-pinned packages.

This PR adds a `no_deps` flag to `install_package()` and passes `no_deps=True` for the pyasic install in `__init__.py` and `config_flow.py`. Validated on a live HA install (pyasic 0.78.12 runs fine against BOS + VNish miners using HA's existing deps).

Context: #19. Pairs with #23 (pin bump) and #24 (coordinator reliability).
