### PR TITLE
Keep last-known-good data on transient failure (stop sensors flapping to 0)

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1096,19 +1096,9 @@ class MinerCoordinator(DataUpdateCoordinator):
         if miner is None:
             self._failure_count += 1
 
-            if self._failure_count <= 3:
-                _LOGGER.warning(
-                    f"Miner is offline – returning zeroed data (failure {self._failure_count}/3)."
-                )
-                return {
-                    **DEFAULT_DATA,
-                    "power_limit_range": {
-                        "min": self.config_entry.data.get(CONF_MIN_POWER, 15),
-                        "max": self.config_entry.data.get(CONF_MAX_POWER, 10000),
-                    },
-                }
-
-            raise UpdateFailed("Miner Offline (consecutive failure)")
+            # Keep last-known-good data on failure instead of returning zeroed
+            # DEFAULT_DATA (which made sensors flap to 0 on transient hiccups).
+            raise UpdateFailed("Miner offline")
 
         # At this point, miner is valid
         _LOGGER.debug(f"Found miner: {self.miner}")
@@ -1141,38 +1131,12 @@ class MinerCoordinator(DataUpdateCoordinator):
                     miner_data = await self.miner.get_data(include=data_options)
                 except Exception as retry_err:
                     self._failure_count += 1
-                    if self._failure_count <= 3:
-                        _LOGGER.warning(
-                            f"Error fetching miner data: {retry_err} – returning zeroed data (failure {self._failure_count}/3)."
-                        )
-                        return {
-                            **DEFAULT_DATA,
-                            "power_limit_range": {
-                                "min": self.config_entry.data.get(CONF_MIN_POWER, 15),
-                                "max": self.config_entry.data.get(
-                                    CONF_MAX_POWER, 10000
-                                ),
-                            },
-                        }
-                    _LOGGER.exception(retry_err)
-                    raise UpdateFailed from retry_err
+                    # Keep last-known-good data on transient failure (no fake 0).
+                    raise UpdateFailed(f"Error fetching miner data: {retry_err}") from retry_err
             else:
                 self._failure_count += 1
-
-                if self._failure_count <= 3:
-                    _LOGGER.warning(
-                        f"Error fetching miner data: {err} – returning zeroed data (failure {self._failure_count}/3)."
-                    )
-                    return {
-                        **DEFAULT_DATA,
-                        "power_limit_range": {
-                            "min": self.config_entry.data.get(CONF_MIN_POWER, 15),
-                            "max": self.config_entry.data.get(CONF_MAX_POWER, 10000),
-                        },
-                    }
-
-                _LOGGER.exception(err)
-                raise UpdateFailed from err
+                # Keep last-known-good data on transient failure (no fake 0).
+                raise UpdateFailed(f"Error fetching miner data: {err}") from err
 
         _LOGGER.debug(f"Got data: {miner_data}")
 


### PR DESCRIPTION
## Problem
On any transient fetch hiccup the coordinator returned **zeroed `DEFAULT_DATA`** for the first 3 consecutive failures before finally raising `UpdateFailed`. That makes `miner_consumption`, `hashrate`, board temps etc. **flap to 0** on a brief network/API blip — which silently corrupts anything downstream that integrates power (energy/cost `utility_meter`, statistics): a phantom 0 W reads as 'the miner stopped', not 'we briefly lost contact'.

## Fix
Drop the zeroed-grace returns and raise `UpdateFailed` immediately on failure. `DataUpdateCoordinator` then **retains the last-known-good `data`** and marks the entities `unavailable` for the duration of the outage — an honest gap in the graph rather than a false zero — and recovers automatically on the next successful poll.

## Behaviour change
- Transient failure: sensors go `unavailable` (was: `0`). Last-good values are retained internally and restored on recovery.
- No change to the happy path.

Field-tested on a Braiins/BOS `S19k Pro`: power held steady instead of dropping to 0 on the intermittent LUCI/BOS fetch failures that previously caused the flapping.

Independent of #24 (that one is detection reliability); this one is failure handling. Touches only `coordinator.py`.