### PR TITLE
Create active-switch & power-limit number for BOS miners regardless of capability flags

### DIFF
--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -24,7 +24,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_WEB_PASSWORD, CONF_WEB_USERNAME, DOMAIN
-from .coordinator import MinerCoordinator, _is_vnish_miner, _set_vnish_overclock
+from .coordinator import (
+    MinerCoordinator,
+    _is_bos_miner,
+    _is_vnish_miner,
+    _set_vnish_overclock,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,14 +52,28 @@ async def async_setup_entry(
     """Add sensors for passed config_entry in HA."""
     coordinator: MinerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    await coordinator.async_config_entry_first_refresh()
+    # Already first-refreshed in __init__; only refresh if needed, so a transient
+    # get_data failure doesn't abort platform setup and drop the number.
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
+
+    miner = coordinator.miner
+    fw_ver = (coordinator.data or {}).get("fw_ver", "") or ""
 
     # Skip power limit slider for VNish miners — use VNish Preset select instead
     is_vnish = (
-        coordinator.miner.web is not None
-        and type(coordinator.miner.web).__name__ == "VNishWebAPI"
+        miner is not None
+        and miner.web is not None
+        and type(miner.web).__name__ == "VNishWebAPI"
     )
-    if coordinator.miner.supports_autotuning and not is_vnish:
+    # Create the power-limit number for any BOS/Braiins miner regardless of the
+    # per-fetch supports_autotuning flag (intermittently unset by pyasic, which
+    # previously left the number missing after a restart). power_limit_range is
+    # always present in the coordinator data, so the entity is safe to create.
+    is_bos = _is_bos_miner(miner, fw_ver) or (
+        miner is not None and "bos" in str(miner).lower()
+    )
+    if (is_bos or (miner is not None and miner.supports_autotuning)) and not is_vnish:
         async_add_entities(
             [
                 MinerPowerLimitNumber(

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import AVALON_MODE_FULL, CONF_AVALON_CONTROL_MODE, DOMAIN
-from .coordinator import MinerCoordinator, _is_avalon_nano_miner
+from .coordinator import MinerCoordinator, _is_avalon_nano_miner, _is_bos_miner
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,12 +74,26 @@ async def async_setup_entry(
         """Create a sensor entity."""
         created.add(key)
 
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator was already first-refreshed in __init__ before platforms are
+    # forwarded; only refresh here if that somehow hasn't happened, so a transient
+    # get_data failure doesn't abort the whole platform setup (and drop the switch).
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
 
     entities = []
 
-    # Standard miner active switch (uses pyasic)
-    if coordinator.miner.supports_shutdown:
+    # Standard miner active switch (uses pyasic).
+    # Create it for any BOS/Braiins miner regardless of the per-fetch
+    # supports_shutdown flag: pyasic intermittently returns a detection with that
+    # flag unset (esp. under restart load), which previously left the switch
+    # missing and broke every automation referencing it. BOS+ miners always
+    # support pause/resume.
+    miner = coordinator.miner
+    fw_ver = (coordinator.data or {}).get("fw_ver", "") or ""
+    is_bos = _is_bos_miner(miner, fw_ver) or (
+        miner is not None and "bos" in str(miner).lower()
+    )
+    if is_bos or (miner is not None and miner.supports_shutdown):
         entities.append(MinerActiveSwitch(coordinator=coordinator))
 
     # Check if user wants full CGMiner control for Avalon miners


### PR DESCRIPTION
## Problem
The active switch (`switch.py`) and the power-limit number (`number.py`) are only created when pyasic reports `supports_shutdown` / `supports_autotuning` **true** on the detected miner. For Braiins/BOS miners these flags are **intermittently unset** — under restart load pyasic sometimes returns a generic/partial detection. The result: after a HA restart the `…_active` switch and `…_power_limit` number are **missing**, every automation/dashboard referencing them breaks, and Home Assistant raises an unknown-entity-reference repair for each.

Field-observed on a Braiins/BOS `S19k Pro No PIC (BOS+)`: a restart created only the sensors (no switch/number); a reload sometimes created the switch, rarely the number — a dice roll across restarts.

## Fix
Create both entities for **any BOS/Braiins miner** (detected via the existing `_is_bos_miner` plus the miner repr) in addition to the capability flag. BOS+ miners always support pause/resume and power targeting, and `power_limit_range` is always present in the coordinator data, so the entities are safe to create unconditionally for them. The capability-flag path is preserved for non-BOS miners.

Also guard the redundant `async_config_entry_first_refresh()` in both platforms (the coordinator is already first-refreshed in `__init__`) so a transient `get_data` failure during platform setup doesn't abort it and drop the entities.

## Result
After a restart the switch + number are now created reliably for the BOS miner (verified live: both 200 across restarts), so the dependent automations work and the repairs stay cleared.

Touches `switch.py` + `number.py` only. Complements #24 (detection timeout/reliability).