### PR TITLE
Sensor: add water inlet/outlet temperature sensors for VNish hydro miners

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -378,9 +378,14 @@ async def _fetch_vnish_temperatures(ip: str, password: str = "admin") -> dict | 
                         chip_temp_max = chip_temp_obj.get("max", 0) if isinstance(chip_temp_obj, dict) else 0
                         chip_temp_min = chip_temp_obj.get("min", 0) if isinstance(chip_temp_obj, dict) else 0
 
+                        # Hydro miners expose water cooling temperatures per chain
+                        water_inlet = chain.get("inlet_water_temp")
+                        water_outlet = chain.get("outlet_water_temp")
+
                         _LOGGER.debug(
-                            "VNish %s chain id=%d slot=%d: pcb=%s/%s, chip=%s/%s",
-                            ip, chain_id, slot, pcb_temp_min, pcb_temp_max, chip_temp_min, chip_temp_max
+                            "VNish %s chain id=%d slot=%d: pcb=%s/%s, chip=%s/%s, water=%s/%s",
+                            ip, chain_id, slot, pcb_temp_min, pcb_temp_max, chip_temp_min, chip_temp_max,
+                            water_inlet, water_outlet,
                         )
 
                         result[slot] = {
@@ -388,6 +393,8 @@ async def _fetch_vnish_temperatures(ip: str, password: str = "admin") -> dict | 
                             "board_temperature_min": pcb_temp_min,
                             "chip_temperature": chip_temp_max,
                             "chip_temperature_min": chip_temp_min,
+                            "water_inlet_temperature": water_inlet,
+                            "water_outlet_temperature": water_outlet,
                         }
                     _LOGGER.debug("VNish %s: final temps result: %s", ip, result)
                     return result if result else None
@@ -1341,12 +1348,16 @@ class MinerCoordinator(DataUpdateCoordinator):
                     board_temp_min = temps.get("board_temperature_min", 0)
                     chip_temp = temps.get("chip_temperature", 0)
                     chip_temp_min = temps.get("chip_temperature_min", 0)
+                    water_inlet = temps.get("water_inlet_temperature")
+                    water_outlet = temps.get("water_outlet_temperature")
                     if slot in data["board_sensors"]:
                         # Preserve hashrate from pyasic, replace temps from VNish API
                         data["board_sensors"][slot]["board_temperature"] = board_temp
                         data["board_sensors"][slot]["board_temperature_min"] = board_temp_min
                         data["board_sensors"][slot]["chip_temperature"] = chip_temp
                         data["board_sensors"][slot]["chip_temperature_min"] = chip_temp_min
+                        data["board_sensors"][slot]["water_inlet_temperature"] = water_inlet
+                        data["board_sensors"][slot]["water_outlet_temperature"] = water_outlet
                     else:
                         # Create new board entry with VNish temps
                         data["board_sensors"][slot] = {
@@ -1354,6 +1365,8 @@ class MinerCoordinator(DataUpdateCoordinator):
                             "board_temperature_min": board_temp_min,
                             "chip_temperature": chip_temp,
                             "chip_temperature_min": chip_temp_min,
+                            "water_inlet_temperature": water_inlet,
+                            "water_outlet_temperature": water_outlet,
                             "board_hashrate": 0,
                         }
                 _LOGGER.debug(

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -219,7 +219,7 @@ async def async_setup_entry(
 
     sensors = []
     is_avalon = _is_avalon_nano_miner(coordinator.miner)
-    is_vnish = _is_vnish_miner(coordinator.miner, coordinator.data.get("fw_ver", ""))
+    is_vnish = _is_vnish_miner(coordinator.miner)
     for s in coordinator.data["miner_sensors"]:
         # Only show active_preset_name for Avalon Nano miners (workmode)
         if s == "active_preset_name" and not is_avalon:
@@ -230,7 +230,7 @@ async def async_setup_entry(
     is_bos = _is_bos_miner(coordinator.miner, coordinator.data.get("fw_ver", ""))
     board_sensors = ["board_temperature", "chip_temperature", "board_hashrate"]
     if is_vnish:
-        board_sensors = ["board_temperature", "board_temperature_min", "chip_temperature", "chip_temperature_min", "board_hashrate"]
+        board_sensors = ["board_temperature", "board_temperature_min", "chip_temperature", "chip_temperature_min", "water_inlet_temperature", "water_outlet_temperature", "board_hashrate"]
     elif is_bos:
         board_sensors = ["board_temperature", "inlet_temperature", "outlet_temperature", "chip_temperature", "water_inlet_temperature", "water_outlet_temperature", "board_hashrate"]
 


### PR DESCRIPTION
First of all — thank you for merging #23, #24, #25, and #26! Great to see those reliability improvements make it upstream.

---

## What this adds

VNish firmware on hydro-cooled miners (e.g. Antminer S19 Pro+Hyd) exposes per-chain water temperatures in the `/api/v1/summary` response:

```json
{
  "miner": {
    "chains": [
      {
        "id": 1,
        "inlet_water_temp": 28,
        "outlet_water_temp": 43,
        ...
      }
    ]
  }
}
```

This PR surfaces those as `water_inlet_temperature` / `water_outlet_temperature` board sensors — reusing the same `SensorEntityDescription` keys that already exist for BOS hydro miners, so no new descriptions are needed.

## Changes

**`coordinator.py`** — `_fetch_vnish_temperatures()`:
- Extract `inlet_water_temp` and `outlet_water_temp` from each chain
- Include them in the returned per-slot dict
- Propagate them into `data["board_sensors"]` in the VNish update block (both the existing-slot and new-slot paths)

**`sensor.py`**:
- Add `water_inlet_temperature` and `water_outlet_temperature` to the VNish board sensor list (placed between min chip temp and hashrate, matching the BOS order)
- Call `_is_vnish_miner(coordinator.miner)` without `fw_ver` at setup time — at that point `fw_ver` is still `None` (first poll hasn't returned yet), so the only reliable detection path is the `miner.web` type check. The `fw_ver` fallback remains valid for call sites that already have it.

## Impact on non-hydro VNish miners

Air-cooled VNish miners are unaffected: `inlet_water_temp` / `outlet_water_temp` are simply absent from the API response, so both values are `None`. The entities are created in the registry with `entity_registry_enabled_default=False` (same as BOS) and remain disabled/unknown until a user explicitly enables them — which they wouldn't on a non-hydro miner.

## Tested on

Antminer S19 Pro+Hyd running VNish firmware, 4 hashboards — all 8 entities (4 × inlet + 4 × outlet) show live values after enabling.