### PR TITLE
Coordinator: absorb single-poll transient failures, mark unavailable on sustained streaks

### DIFF
--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -33,5 +33,18 @@ PYASIC_VERSION = "0.78.12"
 # during setup, leaving the config entry stuck in setup_retry.
 MINER_DETECTION_TIMEOUT = 45
 
+# Number of consecutive update failures absorbed by returning last-known-good
+# data before UpdateFailed is raised. One flaky poll (transient API/HTTP error
+# while the miner is actually fine) then produces a DEBUG line instead of an
+# ERROR + entity flap; a real outage raises on the next poll, ~60s later.
+TRANSIENT_FAILURE_GRACE = 1
+
+# Consecutive update failures after which entities are reported unavailable.
+# The detected-miner object is cached (detect-once), so without this threshold
+# entities would stay available with frozen last-known data forever when a
+# miner is hard powered off at runtime. 3 failures at the 60s update interval
+# ≈ 4 minutes until the device shows as unavailable.
+AVAILABILITY_FAILURE_THRESHOLD = 3
+
 TERA_HASH_PER_SECOND = "TH/s"
 JOULES_PER_TERA_HASH = "J/TH"

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -25,7 +25,9 @@ from .const import (
     CONF_SSH_USERNAME,
     CONF_WEB_PASSWORD,
     CONF_WEB_USERNAME,
+    AVAILABILITY_FAILURE_THRESHOLD,
     MINER_DETECTION_TIMEOUT,
+    TRANSIENT_FAILURE_GRACE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -1070,7 +1072,36 @@ class MinerCoordinator(DataUpdateCoordinator):
     @property
     def available(self):
         """Return if device is available or not."""
-        return self.miner is not None
+        # Never detected (yet) -> unavailable. After detection the miner object
+        # is cached (detect-once), so reachability has to come from the update
+        # results instead: tolerate a short failure streak, then report
+        # unavailable on sustained failures (e.g. miner powered off at the
+        # wall) rather than keeping entities alive with frozen data forever.
+        if self.miner is None:
+            return False
+        return self._failure_count <= AVAILABILITY_FAILURE_THRESHOLD
+
+    def _keep_last_or_fail(self, message: str, err: Exception | None = None):
+        """Handle a failed poll: absorb short hiccups, raise on streaks.
+
+        The first TRANSIENT_FAILURE_GRACE consecutive failures return the
+        last-known-good data (DEBUG only), so one flaky poll doesn't produce
+        an ERROR log line and a state flap. Anything longer raises
+        UpdateFailed and goes through the standard coordinator handling.
+        """
+        self._failure_count += 1
+        if self.data and self._failure_count <= TRANSIENT_FAILURE_GRACE:
+            _LOGGER.debug(
+                "Update for %s failed (consecutive failure %d, within grace), "
+                "keeping last data: %s",
+                self.name,
+                self._failure_count,
+                message,
+            )
+            return self.data
+        if err is not None:
+            raise UpdateFailed(message) from err
+        raise UpdateFailed(message)
 
     async def get_miner(self):
         """Get a valid Miner instance."""
@@ -1118,11 +1149,9 @@ class MinerCoordinator(DataUpdateCoordinator):
         miner = await self.get_miner()
 
         if miner is None:
-            self._failure_count += 1
-
             # Keep last-known-good data on failure instead of returning zeroed
             # DEFAULT_DATA (which made sensors flap to 0 on transient hiccups).
-            raise UpdateFailed("Miner offline")
+            return self._keep_last_or_fail("Miner offline")
 
         # At this point, miner is valid
         _LOGGER.debug(f"Found miner: {self.miner}")
@@ -1154,13 +1183,15 @@ class MinerCoordinator(DataUpdateCoordinator):
                 try:
                     miner_data = await self.miner.get_data(include=data_options)
                 except Exception as retry_err:
-                    self._failure_count += 1
                     # Keep last-known-good data on transient failure (no fake 0).
-                    raise UpdateFailed(f"Error fetching miner data: {retry_err}") from retry_err
+                    return self._keep_last_or_fail(
+                        f"Error fetching miner data: {retry_err}", retry_err
+                    )
             else:
-                self._failure_count += 1
                 # Keep last-known-good data on transient failure (no fake 0).
-                raise UpdateFailed(f"Error fetching miner data: {err}") from err
+                return self._keep_last_or_fail(
+                    f"Error fetching miner data: {err}", err
+                )
 
         _LOGGER.debug(f"Got data: {miner_data}")
 

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    AVAILABILITY_FAILURE_THRESHOLD,
     AVALON_MODE_FULL,
     CONF_AVALON_CONTROL_MODE,
     CONF_IP,
@@ -25,7 +26,6 @@ from .const import (
     CONF_SSH_USERNAME,
     CONF_WEB_PASSWORD,
     CONF_WEB_USERNAME,
-    AVAILABILITY_FAILURE_THRESHOLD,
     MINER_DETECTION_TIMEOUT,
     TRANSIENT_FAILURE_GRACE,
 )


### PR DESCRIPTION
## What

Two changes to the coordinator's failure handling, driven by production logs from 2026-06-10:

1. **Transient-failure grace**: a single flaky poll (e.g. `Failed to call is_mining`, `HTTP error sending 'settings'` while the miner is reachable and actively mining) raised `UpdateFailed` immediately, producing one ERROR log line per blip plus downstream warning spam from group/utility_meter helpers. `_failure_count` was already tracked but never used. Now the first `TRANSIENT_FAILURE_GRACE` (=1) consecutive failures return last-known-good data with a DEBUG line; a real outage still raises on the next poll ~60s later.

2. **Unavailable on sustained streaks**: because the detected miner object is cached (detect-once, #24), `coordinator.available` stayed `True` forever once detection succeeded — a miner hard powered off at runtime kept all entities available with frozen data indefinitely. `available` now flips to `False` after `AVAILABILITY_FAILURE_THRESHOLD` (=3) consecutive failures and recovers automatically on the next successful poll.

## Evidence

On my production instance (S19 Pro Hydro/VNish + S19k Pro/BOS+), 2026-06-10 produced 3 ERROR entries from single-cycle transients while the miners were reachable — all three would have been DEBUG with this change. Real power-off now produces exactly one ERROR per offline transition.

## Status

Running combined with #30/#31 on my production HA since 2026-06-10 evening. **I'll observe it for a few more days before merging** — leaving as PR until then.
