### PR TITLE
VNish: keep last known board temperatures when the REST temp fetch fails

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1375,10 +1375,45 @@ class MinerCoordinator(DataUpdateCoordinator):
                     data["board_sensors"],
                 )
             else:
-                _LOGGER.warning(
-                    "VNish %s: temperature fetch failed, using pyasic fallback",
-                    self.miner.ip,
+                # The VNish REST endpoint is the only temperature source for
+                # these miners (pyasic does not deliver VNish board temps -
+                # that's why this fetch exists). On a transient fetch failure,
+                # keep the last known temperatures instead of pushing the
+                # sensors to unknown for one poll cycle, which also spams any
+                # downstream group/template sensors.
+                prev_boards = (self.data or {}).get("board_sensors") or {}
+                temp_keys = (
+                    "board_temperature",
+                    "board_temperature_min",
+                    "chip_temperature",
+                    "chip_temperature_min",
+                    "water_inlet_temperature",
+                    "water_outlet_temperature",
                 )
+                restored = 0
+                for slot, prev_vals in prev_boards.items():
+                    cur = data["board_sensors"].get(slot)
+                    if cur is None:
+                        continue
+                    for key in temp_keys:
+                        # 0 is the VNish placeholder for "no reading", not a
+                        # plausible operating temperature.
+                        if not cur.get(key) and prev_vals.get(key):
+                            cur[key] = prev_vals[key]
+                            restored += 1
+                if restored:
+                    _LOGGER.info(
+                        "VNish %s: temperature fetch failed, keeping %d last "
+                        "known temperature value(s) until the next poll",
+                        self.miner.ip,
+                        restored,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "VNish %s: temperature fetch failed and no previous "
+                        "temperatures to fall back on",
+                        self.miner.ip,
+                    )
 
         # Fetch BOS miner stats and hashboard temps via REST API
         if _is_bos_miner(self.miner, miner_data.fw_ver):


### PR DESCRIPTION
## What

When `_fetch_vnish_temperatures` fails, the code logged *"using pyasic fallback"* — but pyasic does not provide VNish board temperatures (that's exactly why the direct REST fetch exists). So a single failed fetch pushed every board/chip temperature sensor to `unknown` for one poll cycle, even though the overall update succeeded.

Now temperatures that came back empty are refilled from the coordinator's last data (INFO log), consistent with the keep-last-known-good behaviour introduced in #26. If there is nothing to restore (first poll), the warning remains.

## Evidence

Production 2026-06-10 12:11 (S19 Pro Hydro, VNish 1.3.3, while actively mining): one transient REST failure → 8 group-sensor warnings (`Unable to use state ... value unknown excluded from calculation`) from a single blip.

## Status

Running combined with #29/#31 on my production HA since 2026-06-10 evening. **I'll observe it for a few more days before merging.**
