### PR TITLE
Set up offline miners from a cached device profile instead of failing with ConfigEntryNotReady

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,15 @@ from homeassistant.exceptions import ConfigEntryNotReady
 if TYPE_CHECKING:
     from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_IP, DOMAIN, MINER_DETECTION_TIMEOUT, PYASIC_VERSION
+from .const import (
+    CONF_CACHED_PROFILE,
+    CONF_IP,
+    DOMAIN,
+    MINER_DETECTION_TIMEOUT,
+    PYASIC_VERSION,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -115,16 +124,32 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         miner = await asyncio.wait_for(
             pyasic.get_miner(miner_ip), timeout=MINER_DETECTION_TIMEOUT
         )
-    except (TimeoutError, asyncio.TimeoutError) as err:
-        raise ConfigEntryNotReady("Miner detection timed out") from err
+    except (TimeoutError, asyncio.TimeoutError):
+        miner = None
 
-    if miner is None:
+    if miner is None and not config_entry.data.get(CONF_CACHED_PROFILE):
+        # Never seen this miner successfully -> nothing to build entities
+        # from; keep the classic retry behaviour.
         raise ConfigEntryNotReady("Miner could not be found.")
 
     m_coordinator = MinerCoordinator(hass, config_entry)
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = m_coordinator
 
-    await m_coordinator.async_config_entry_first_refresh()
+    if miner is None:
+        # Miner is unreachable (typically powered off to save energy) but we
+        # have a cached device profile from an earlier successful update: set
+        # up from that instead of failing with ConfigEntryNotReady, which
+        # showed the integration as broken ("retrying setup") for as long as
+        # the miner stayed off. Entities are created unavailable and recover
+        # automatically once the miner is powered on again.
+        _LOGGER.info(
+            "Miner %s is unreachable; setting up from the cached device "
+            "profile - entities stay unavailable until the miner returns",
+            miner_ip,
+        )
+        m_coordinator.prime_from_cached_profile()
+    else:
+        await m_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 

--- a/custom_components/miner/button.py
+++ b/custom_components/miner/button.py
@@ -26,10 +26,16 @@ async def async_setup_entry(
     """Set up Avalon miner buttons from config entry."""
     coordinator: MinerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator data is primed in __init__ (live first refresh or cached
+    # profile when the miner is powered off); only refresh here if needed.
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
 
     # Only add reboot button for Avalon Nano miners
-    if _is_avalon_nano_miner(coordinator.miner):
+    if _is_avalon_nano_miner(coordinator.miner) or (
+        coordinator.miner is None
+        and coordinator.cached_profile.get("is_avalon", False)
+    ):
         async_add_entities([AvalonRebootButton(coordinator)])
 
 

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -13,6 +13,12 @@ CONF_MIN_POWER = "min_power"
 CONF_MAX_POWER = "max_power"
 CONF_AVALON_CONTROL_MODE = "avalon_control_mode"
 
+# Config-entry data key for the device profile captured on the last successful
+# update (identity, capabilities, firmware-type flags). Lets the integration
+# set up while the miner is powered off (e.g. for energy saving) instead of
+# failing with ConfigEntryNotReady and showing as broken until it returns.
+CONF_CACHED_PROFILE = "cached_device_profile"
+
 # Avalon control mode options
 AVALON_MODE_SIMPLE = "simple"  # Native pyasic only
 AVALON_MODE_FULL = "full"  # Full CGMiner API control (workmode, LED, mining switch)

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1144,6 +1144,11 @@ class MinerCoordinator(DataUpdateCoordinator):
                 "supports_autotuning": bool(
                     getattr(miner, "supports_autotuning", False)
                 ),
+                # VNish >= 1.3.3 reports a throttle level (vnish_throttle is
+                # populated by the throttle feature branch; None/absent on
+                # older firmware) - lets the throttle entity be re-created
+                # after an offline setup.
+                "has_throttle": data.get("vnish_throttle") is not None,
             }
             if profile != self.config_entry.data.get(CONF_CACHED_PROFILE):
                 self.hass.config_entries.async_update_entry(

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1,6 +1,7 @@
 """Miner DataUpdateCoordinator."""
 
 import asyncio
+import copy
 import logging
 import re
 from datetime import timedelta
@@ -17,6 +18,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import (
     AVALON_MODE_FULL,
     CONF_AVALON_CONTROL_MODE,
+    CONF_CACHED_PROFILE,
     CONF_IP,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -1053,6 +1055,9 @@ class MinerCoordinator(DataUpdateCoordinator):
         """Initialize MinerCoordinator object."""
         self.miner = None
         self._failure_count = 0
+        # True while running on cached-profile data because the miner was
+        # unreachable during setup; cleared on the first successful update.
+        self._primed_offline = False
         super().__init__(
             hass=hass,
             logger=_LOGGER,
@@ -1071,6 +1076,82 @@ class MinerCoordinator(DataUpdateCoordinator):
     def available(self):
         """Return if device is available or not."""
         return self.miner is not None
+
+    @property
+    def cached_profile(self) -> dict:
+        """Device profile captured on the last successful update (may be {})."""
+        return self.config_entry.data.get(CONF_CACHED_PROFILE) or {}
+
+    def prime_from_cached_profile(self) -> None:
+        """Populate coordinator data from the cached device profile.
+
+        Used when the miner cannot be detected during setup (typically
+        powered off to save energy): entities are created from the cached
+        identity and report unavailable (self.miner is None) until the miner
+        returns; detection is retried on every poll via get_miner().
+        """
+        profile = self.cached_profile
+        data = copy.deepcopy(DEFAULT_DATA)
+        data["hostname"] = profile.get("hostname")
+        data["mac"] = profile.get("mac")
+        data["make"] = profile.get("make")
+        data["model"] = profile.get("model")
+        data["fw_ver"] = profile.get("fw_ver")
+        data["ip"] = self.config_entry.data.get(CONF_IP)
+        data["power_limit_range"] = {
+            "min": self.config_entry.data.get(CONF_MIN_POWER, 15),
+            "max": self.config_entry.data.get(CONF_MAX_POWER, 10000),
+        }
+        self.data = data
+        self._primed_offline = True
+
+    def _persist_device_profile(self, data) -> None:
+        """Store the device profile in the config entry (only when changed)."""
+        try:
+            miner = self.miner
+            fw_ver = str(data.get("fw_ver") or "")
+            fw_lower = fw_ver.lower()
+            model_lower = str(data.get("model") or "").lower()
+            has_modern_vnish_api = (
+                miner is not None
+                and miner.web is not None
+                and type(miner.web).__name__ == "VNishWebAPI"
+            )
+            profile = {
+                "hostname": data.get("hostname"),
+                "mac": data.get("mac"),
+                "make": data.get("make"),
+                "model": data.get("model"),
+                "fw_ver": data.get("fw_ver"),
+                "is_vnish": _is_vnish_miner(miner, fw_ver),
+                "is_bos": _is_bos_miner(miner, fw_ver),
+                "is_avalon": _is_avalon_nano_miner(miner),
+                "is_bitaxe": _is_bitaxe_miner(miner),
+                # Mirrors switch._is_vnish_legacy_miner (CGI-bin based VNish 3.x)
+                "is_vnish_legacy": (
+                    not has_modern_vnish_api
+                    and (
+                        "vnish 3" in fw_lower
+                        or "vnish-3" in fw_lower
+                        or "s9d" in model_lower
+                        or "s9 dual" in model_lower
+                    )
+                ),
+                "expected_hashboards": getattr(miner, "expected_hashboards", None),
+                "expected_fans": getattr(miner, "expected_fans", None),
+                "fan_count": len(data.get("fan_sensors") or {}),
+                "supports_shutdown": bool(getattr(miner, "supports_shutdown", False)),
+                "supports_autotuning": bool(
+                    getattr(miner, "supports_autotuning", False)
+                ),
+            }
+            if profile != self.config_entry.data.get(CONF_CACHED_PROFILE):
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={**self.config_entry.data, CONF_CACHED_PROFILE: profile},
+                )
+        except Exception as err:  # profile caching must never break an update
+            _LOGGER.debug("Could not persist device profile: %s", err)
 
     async def get_miner(self):
         """Get a valid Miner instance."""
@@ -1118,6 +1199,18 @@ class MinerCoordinator(DataUpdateCoordinator):
         miner = await self.get_miner()
 
         if miner is None:
+            if self._primed_offline:
+                # Set up from the cached profile while the miner is powered
+                # off: this state is expected, so stay quiet (no ERROR per
+                # poll) - entities already report unavailable via the
+                # available property (self.miner is None). Detection is
+                # retried by get_miner() on every poll.
+                _LOGGER.debug(
+                    "%s: miner still offline, waiting for it to return",
+                    self.name,
+                )
+                return self.data
+
             self._failure_count += 1
 
             # Keep last-known-good data on failure instead of returning zeroed
@@ -1164,8 +1257,9 @@ class MinerCoordinator(DataUpdateCoordinator):
 
         _LOGGER.debug(f"Got data: {miner_data}")
 
-        # Success: reset the failure count
+        # Success: reset the failure count and leave primed-offline mode
         self._failure_count = 0
+        self._primed_offline = False
 
         def normalize_hashrate_to_th(value):
             """Normalize hashrate to TH/s.
@@ -1429,5 +1523,9 @@ class MinerCoordinator(DataUpdateCoordinator):
             if bitaxe_summary:
                 data["bitaxe_best_share"] = bitaxe_summary.get("best_share")
                 data["bitaxe_found_blocks"] = bitaxe_summary.get("found_blocks")
+
+        # Cache identity/capabilities so the next setup can succeed while the
+        # miner is powered off (see prime_from_cached_profile).
+        self._persist_device_profile(data)
 
         return data

--- a/custom_components/miner/light.py
+++ b/custom_components/miner/light.py
@@ -33,10 +33,16 @@ async def async_setup_entry(
     """Set up Avalon LED light from config entry."""
     coordinator: MinerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator data is primed in __init__ (live first refresh or cached
+    # profile when the miner is powered off); only refresh here if needed.
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
 
     # Only add LED light for Avalon Nano miners
-    if _is_avalon_nano_miner(coordinator.miner):
+    if _is_avalon_nano_miner(coordinator.miner) or (
+        coordinator.miner is None
+        and coordinator.cached_profile.get("is_avalon", False)
+    ):
         async_add_entities([AvalonLedLight(coordinator)])
 
 

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -19,6 +19,7 @@ from homeassistant.components.sensor import EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry, entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -58,6 +59,8 @@ async def async_setup_entry(
         await coordinator.async_config_entry_first_refresh()
 
     miner = coordinator.miner
+    offline = miner is None
+    profile = coordinator.cached_profile
     fw_ver = (coordinator.data or {}).get("fw_ver", "") or ""
 
     # Skip power limit slider for VNish miners — use VNish Preset select instead
@@ -65,15 +68,21 @@ async def async_setup_entry(
         miner is not None
         and miner.web is not None
         and type(miner.web).__name__ == "VNishWebAPI"
-    )
+    ) or (offline and profile.get("is_vnish", False))
     # Create the power-limit number for any BOS/Braiins miner regardless of the
     # per-fetch supports_autotuning flag (intermittently unset by pyasic, which
     # previously left the number missing after a restart). power_limit_range is
     # always present in the coordinator data, so the entity is safe to create.
-    is_bos = _is_bos_miner(miner, fw_ver) or (
-        miner is not None and "bos" in str(miner).lower()
+    is_bos = (
+        _is_bos_miner(miner, fw_ver)
+        or (miner is not None and "bos" in str(miner).lower())
+        or (offline and profile.get("is_bos", False))
     )
-    if (is_bos or (miner is not None and miner.supports_autotuning)) and not is_vnish:
+    if (
+        is_bos
+        or (miner is not None and miner.supports_autotuning)
+        or (offline and profile.get("supports_autotuning", False))
+    ) and not is_vnish:
         async_add_entities(
             [
                 MinerPowerLimitNumber(
@@ -85,7 +94,9 @@ async def async_setup_entry(
 
     # Add VNish voltage and frequency number entities
     fw_ver = coordinator.data.get("fw_ver", "") or ""
-    if _is_vnish_miner(coordinator.miner, fw_ver):
+    if _is_vnish_miner(coordinator.miner, fw_ver) or (
+        offline and profile.get("is_vnish", False)
+    ):
         async_add_entities(
             [
                 VNishVoltageNumber(coordinator=coordinator),
@@ -229,6 +240,10 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
         import pyasic  # lazy import to avoid blocking event loop
 
         miner = self.coordinator.miner
+        if miner is None:
+            raise HomeAssistantError(
+                f"{self.coordinator.config_entry.title} is offline"
+            )
 
         _LOGGER.debug(
             f"{self.coordinator.config_entry.title}: setting power limit to {value}."

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -187,7 +187,11 @@ def is_avalon_nano_miner(miner) -> bool:
 def is_vnish_miner(coordinator: MinerCoordinator) -> bool:
     """Check if miner is running VNish firmware."""
     miner = coordinator.miner
-    if miner is None or miner.web is None:
+    if miner is None:
+        # Offline setup from cached profile - use the flag captured while
+        # the miner was last online.
+        return bool(coordinator.cached_profile.get("is_vnish", False))
+    if miner.web is None:
         return False
     return type(miner.web).__name__ == "VNishWebAPI"
 
@@ -380,7 +384,10 @@ async def async_setup_entry(
     """Add select entities for passed config_entry in HA."""
     coordinator: MinerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator data is primed in __init__ (live first refresh or cached
+    # profile when the miner is powered off); only refresh here if needed.
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
 
     entities = []
 
@@ -388,7 +395,11 @@ async def async_setup_entry(
     avalon_mode = config_entry.data.get(CONF_AVALON_CONTROL_MODE, AVALON_MODE_FULL)
 
     # Add workmode and LED effect select for Avalon Nano miners (only in full mode)
-    if is_avalon_nano_miner(coordinator.miner) and avalon_mode == AVALON_MODE_FULL:
+    is_avalon = is_avalon_nano_miner(coordinator.miner) or (
+        coordinator.miner is None
+        and coordinator.cached_profile.get("is_avalon", False)
+    )
+    if is_avalon and avalon_mode == AVALON_MODE_FULL:
         _LOGGER.info(
             "Detected Avalon Nano miner at %s, adding workmode and LED controls (full mode)",
             coordinator.data.get("ip"),

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -225,10 +225,12 @@ class VNishAPI:
                     self._token = data.get("token")
                     _LOGGER.debug("VNish unlock OK, token=%s", self._token)
                     return bool(self._token)
-                _LOGGER.error("VNish unlock failed: HTTP %s", resp.status)
+                _LOGGER.warning("VNish unlock failed: HTTP %s", resp.status)
                 return False
         except Exception as e:
-            _LOGGER.error("VNish unlock error: %s", e)
+            # Connection-level failures are expected while the miner is
+            # powered off (offline setup / energy saving) - keep them quiet.
+            _LOGGER.debug("VNish unlock error: %s", e)
             return False
 
     async def get_presets(self, session: aiohttp.ClientSession) -> list[dict]:
@@ -242,10 +244,11 @@ class VNishAPI:
                 if resp.status == 200:
                     data = await resp.json()
                     return data if isinstance(data, list) else data.get("presets", [])
-                _LOGGER.error("VNish get_presets failed: HTTP %s", resp.status)
+                _LOGGER.warning("VNish get_presets failed: HTTP %s", resp.status)
                 return []
         except Exception as e:
-            _LOGGER.error("VNish get_presets error: %s", e)
+            # Quiet on connection failures - expected for a powered-off miner.
+            _LOGGER.debug("VNish get_presets error: %s", e)
             return []
 
     async def get_settings(self, session: aiohttp.ClientSession) -> dict:
@@ -258,10 +261,11 @@ class VNishAPI:
             ) as resp:
                 if resp.status == 200:
                     return await resp.json()
-                _LOGGER.error("VNish get_settings failed: HTTP %s", resp.status)
+                _LOGGER.warning("VNish get_settings failed: HTTP %s", resp.status)
                 return {}
         except Exception as e:
-            _LOGGER.error("VNish get_settings error: %s", e)
+            # Quiet on connection failures - expected for a powered-off miner.
+            _LOGGER.debug("VNish get_settings error: %s", e)
             return {}
 
     async def apply_preset(

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -215,11 +215,24 @@ async def async_setup_entry(
             entity_description=description,
         )
 
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator data is primed in __init__ (live first refresh or cached
+    # profile when the miner is powered off); only refresh here if that
+    # somehow hasn't happened.
+    if coordinator.data is None:
+        await coordinator.async_config_entry_first_refresh()
+
+    # When the miner is offline (set up from the cached profile), the live
+    # miner object is None - fall back to the cached firmware-type flags and
+    # capabilities so the same entity set is created as when it is online.
+    miner = coordinator.miner
+    offline = miner is None
+    profile = coordinator.cached_profile
 
     sensors = []
-    is_avalon = _is_avalon_nano_miner(coordinator.miner)
-    is_vnish = _is_vnish_miner(coordinator.miner)
+    is_avalon = _is_avalon_nano_miner(miner) or (
+        offline and profile.get("is_avalon", False)
+    )
+    is_vnish = _is_vnish_miner(miner) or (offline and profile.get("is_vnish", False))
     for s in coordinator.data["miner_sensors"]:
         # Only show active_preset_name for Avalon Nano miners (workmode)
         if s == "active_preset_name" and not is_avalon:
@@ -227,25 +240,35 @@ async def async_setup_entry(
         sensors.append(_create_miner_entity(s))
 
     # Build board sensor list - min temps for VNish, inlet/outlet for BOS
-    is_bos = _is_bos_miner(coordinator.miner, coordinator.data.get("fw_ver", ""))
+    is_bos = _is_bos_miner(miner, coordinator.data.get("fw_ver", "")) or (
+        offline and profile.get("is_bos", False)
+    )
     board_sensors = ["board_temperature", "chip_temperature", "board_hashrate"]
     if is_vnish:
         board_sensors = ["board_temperature", "board_temperature_min", "chip_temperature", "chip_temperature_min", "water_inlet_temperature", "water_outlet_temperature", "board_hashrate"]
     elif is_bos:
         board_sensors = ["board_temperature", "inlet_temperature", "outlet_temperature", "chip_temperature", "water_inlet_temperature", "water_outlet_temperature", "board_hashrate"]
 
-    for board in range(coordinator.miner.expected_hashboards or 3):
+    expected_hashboards = (
+        miner.expected_hashboards if miner is not None
+        else profile.get("expected_hashboards")
+    )
+    for board in range(expected_hashboards or 3):
         for s in board_sensors:
             sensors.append(_create_board_entity(board, s))
     model_name = coordinator.data.get("model", "") or ""
     is_hydro = "hyd" in model_name.lower()
     if not is_hydro:
-        for fan in range(coordinator.miner.expected_fans or len(coordinator.data.get("fan_sensors", {})) or 2):
+        expected_fans = (
+            miner.expected_fans if miner is not None
+            else (profile.get("expected_fans") or profile.get("fan_count"))
+        )
+        for fan in range(expected_fans or len(coordinator.data.get("fan_sensors", {})) or 2):
             for s in ["fan_speed"]:
                 sensors.append(_create_fan_entity(fan, s))
 
     # Add Avalon-specific sensors (Best Share, Found Blocks)
-    if _is_avalon_nano_miner(coordinator.miner):
+    if is_avalon:
         for sensor_key in ["best_share", "found_blocks"]:
             description = ENTITY_DESCRIPTION_KEY_MAP.get(sensor_key)
             if description:
@@ -258,7 +281,7 @@ async def async_setup_entry(
                 )
 
     # Add VNish-specific sensors (Best Share, Found Blocks)
-    if _is_vnish_miner(coordinator.miner):
+    if is_vnish:
         for sensor_key in ["best_share", "found_blocks"]:
             description = ENTITY_DESCRIPTION_KEY_MAP.get(sensor_key)
             if description:
@@ -271,7 +294,7 @@ async def async_setup_entry(
                 )
 
     # Add BOS-specific sensors (Best Share, Found Blocks)
-    if _is_bos_miner(coordinator.miner, coordinator.data.get("fw_ver", "")):
+    if is_bos:
         for sensor_key in ["best_share", "found_blocks"]:
             description = ENTITY_DESCRIPTION_KEY_MAP.get(sensor_key)
             if description:
@@ -284,7 +307,7 @@ async def async_setup_entry(
                 )
 
     # Add BitAxe-specific sensors (Best Share, Found Blocks)
-    if _is_bitaxe_miner(coordinator.miner):
+    if _is_bitaxe_miner(miner) or (offline and profile.get("is_bitaxe", False)):
         for sensor_key in ["best_share", "found_blocks"]:
             description = ENTITY_DESCRIPTION_KEY_MAP.get(sensor_key)
             if description:

--- a/custom_components/miner/services.py
+++ b/custom_components/miner/services.py
@@ -31,11 +31,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         miner_ids = call.data[CONF_DEVICE_ID]
 
         if not miner_ids:
-            return
+            return []
 
         registry = async_get_device_registry(hass)
 
-        return await asyncio.gather(
+        miners = await asyncio.gather(
             *(
                 [
                     hass_devices[registry.async_get(d).primary_config_entry].get_miner()
@@ -43,6 +43,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 ]
             )
         )
+        # get_miner() returns None for an unreachable/powered-off miner
+        # (e.g. an entry set up from the cached profile) - skip those.
+        return [m for m in miners if m is not None]
 
     async def reboot(call: ServiceCall) -> None:
         miners = await get_miners(call)

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -10,6 +10,7 @@ import aiohttp
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry, entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -31,7 +32,9 @@ def _is_vnish_legacy_miner(coordinator: MinerCoordinator) -> bool:
     are explicitly excluded to avoid any interference.
     """
     if coordinator.miner is None:
-        return False
+        # Offline setup from cached profile - use the flag captured while
+        # the miner was last online.
+        return bool(coordinator.cached_profile.get("is_vnish_legacy", False))
 
     # CRITICAL: If miner has modern VNishWebAPI, it is NOT legacy - never interfere
     has_modern_api = coordinator.miner.web is not None and type(
@@ -89,18 +92,29 @@ async def async_setup_entry(
     # missing and broke every automation referencing it. BOS+ miners always
     # support pause/resume.
     miner = coordinator.miner
+    offline = miner is None
+    profile = coordinator.cached_profile
     fw_ver = (coordinator.data or {}).get("fw_ver", "") or ""
-    is_bos = _is_bos_miner(miner, fw_ver) or (
-        miner is not None and "bos" in str(miner).lower()
+    is_bos = (
+        _is_bos_miner(miner, fw_ver)
+        or (miner is not None and "bos" in str(miner).lower())
+        or (offline and profile.get("is_bos", False))
     )
-    if is_bos or (miner is not None and miner.supports_shutdown):
+    if (
+        is_bos
+        or (miner is not None and miner.supports_shutdown)
+        or (offline and profile.get("supports_shutdown", False))
+    ):
         entities.append(MinerActiveSwitch(coordinator=coordinator))
 
     # Check if user wants full CGMiner control for Avalon miners
     avalon_mode = config_entry.data.get(CONF_AVALON_CONTROL_MODE, AVALON_MODE_FULL)
 
     # Avalon Nano 3s mining switch (uses CGMiner API) - only in full mode
-    if _is_avalon_nano_miner(coordinator.miner) and avalon_mode == AVALON_MODE_FULL:
+    is_avalon = _is_avalon_nano_miner(miner) or (
+        offline and profile.get("is_avalon", False)
+    )
+    if is_avalon and avalon_mode == AVALON_MODE_FULL:
         entities.append(AvalonMiningSwitch(coordinator=coordinator))
 
     # Legacy VNish 3.x mining switch (uses CGI-bin endpoints)
@@ -150,6 +164,10 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     async def async_turn_on(self) -> None:
         """Turn on miner."""
         miner = self.coordinator.miner
+        if miner is None:
+            raise HomeAssistantError(
+                f"{self.coordinator.config_entry.title} is offline"
+            )
         _LOGGER.debug(f"{self.coordinator.config_entry.title}: Resume mining.")
         if not miner.supports_shutdown:
             raise TypeError(f"{miner}: Shutdown not supported.")
@@ -179,6 +197,10 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     async def async_turn_off(self) -> None:
         """Turn off miner."""
         miner = self.coordinator.miner
+        if miner is None:
+            raise HomeAssistantError(
+                f"{self.coordinator.config_entry.title} is offline"
+            )
         _LOGGER.debug(f"{self.coordinator.config_entry.title}: Stop mining.")
         if not miner.supports_shutdown:
             raise TypeError(f"{miner}: Shutdown not supported.")


### PR DESCRIPTION
## Problem

A miner that is intentionally powered off (energy saving / PV-surplus-only mining) made every HA restart end in `ConfigEntryNotReady`: the integration showed **"Failed to set up / retrying"** for as long as the miner stayed off (in my case: whole nights), its entities did not exist, and every automation referencing them logged *"referenced entities ... are missing"*. For surplus-mining setups, being powered off is the normal state, not an error.

## Approach

Follows the pattern of gold-tier core integrations (e.g. Shelly) that set up known devices from persisted identity while offline:

- **coordinator**: on every successful update, persist an identity/capability profile (mac, model, fw_ver, firmware-type flags, expected boards/fans, supports_shutdown/autotuning) into the config entry data (`cached_device_profile`, write-on-change only).
- **`__init__`**: if detection fails during setup but a cached profile exists, set up anyway — coordinator data is primed from the profile, entities are created and report unavailable, and detection is retried on every poll via the existing lazy `get_miner()`. A fresh install with no profile keeps the classic `ConfigEntryNotReady` retry.
- **platforms**: entity-creation conditions fall back to the cached flags/capabilities when the live miner object is `None`; the unconditional `first_refresh` calls are guarded so platform setup cannot abort while offline.
- **quiet while expected-offline**: polls in primed-offline state log DEBUG instead of raising `UpdateFailed`; VNish preset-select REST connection failures are DEBUG too.
- **action guards**: switch turn_on/off and power-limit set raise `HomeAssistantError('... is offline')` instead of `AttributeError`; services skip unreachable miners.

## Tested end-to-end on production (2026-06-10)

1. Miner online → profile persisted correctly (S19 Pro Hydro, VNish 1.3.3, MAC, 4 boards, 0 fans, capabilities).
2. Miner hard powered off → HA restart → entry state **`loaded`** (previously `setup_retry`), all entities exist as `unavailable`, zero miner errors in the log.
3. Miner powered back on → entities recover automatically on the next poll.

## Notes

- Has a small, intentional overlap with #29 in the coordinator failure path — whichever merges second needs a trivial conflict resolution (I have the combined merge running locally and can rebase).
- **I'll observe this on my production instance for a few more days before merging.**
