### PR TITLE
VNish preset select: retry preset fetch instead of giving up after one shot

### DIFF
--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -616,6 +616,7 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         self._presets: list[dict] = []
         self._preset_map: dict[str, str] = {}  # pretty -> name
         self._current_preset: str | None = None
+        self._fetch_in_progress = False
 
     @property
     def name(self) -> str | None:
@@ -712,38 +713,61 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         await self._fetch_presets()
 
     async def _fetch_presets(self) -> None:
-        """Fetch available presets from VNish API."""
-        async with aiohttp.ClientSession() as session:
-            if not await self._api.unlock(session):
-                return
+        """Fetch available presets from the VNish API.
 
-            presets = await self._api.get_presets(session)
-            if not presets:
-                return
+        Runs once from async_added_to_hass and is retried on later coordinator
+        updates while the option list is still empty (see
+        _handle_coordinator_update). A single fetch can fail transiently - e.g.
+        unlock/get timing out while pyasic saturates the event loop during HA
+        startup - and without a retry the select would stay `unavailable` until
+        the next manual restart.
+        """
+        if self._fetch_in_progress:
+            return
+        self._fetch_in_progress = True
+        try:
+            async with aiohttp.ClientSession() as session:
+                if not await self._api.unlock(session):
+                    return
 
-            self._presets = presets
-            self._preset_map = {}
-            for p in presets:
-                pretty = p.get("pretty", p.get("name", "unknown"))
-                name = p.get("name", "unknown")
-                self._preset_map[pretty] = name
+                presets = await self._api.get_presets(session)
+                if not presets:
+                    return
 
-            settings = await self._api.get_settings(session)
-            if settings:
-                current_name = (
-                    settings.get("miner", {}).get("overclock", {}).get("preset")
-                )
-                if current_name:
-                    for pretty, name in self._preset_map.items():
-                        if name == current_name:
-                            self._current_preset = pretty
-                            break
+                self._presets = presets
+                self._preset_map = {}
+                for p in presets:
+                    pretty = p.get("pretty", p.get("name", "unknown"))
+                    name = p.get("name", "unknown")
+                    self._preset_map[pretty] = name
+
+                settings = await self._api.get_settings(session)
+                if settings:
+                    current_name = (
+                        settings.get("miner", {}).get("overclock", {}).get("preset")
+                    )
+                    if current_name:
+                        for pretty, name in self._preset_map.items():
+                            if name == current_name:
+                                self._current_preset = pretty
+                                break
+        finally:
+            self._fetch_in_progress = False
 
         self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update local state when coordinator data changes."""
+        # Retry the one-shot preset fetch if it never populated (e.g. it timed
+        # out during startup). Stops retrying once _preset_map is filled.
+        if (
+            not self._preset_map
+            and not self._fetch_in_progress
+            and self.coordinator.available
+            and self.hass is not None
+        ):
+            self.hass.async_create_task(self._fetch_presets())
         vnish_preset = self.coordinator.data.get("vnish_preset")
         if vnish_preset and self._preset_map:
             for pretty, name in self._preset_map.items():


### PR DESCRIPTION
## Problem

The `select.<miner>_vnish_preset` entity can end up permanently `unavailable` even though the miner is online and every other entity works.

`VNishPresetSelect._fetch_presets()` runs exactly once, from `async_added_to_hass`: it unlocks the miner, calls `GET /api/v1/autotune/presets`, and fills `_preset_map`. The entity's `available` is `coordinator.available and bool(self._preset_map)`.

If that single fetch fails transiently — which is easy during HA startup, where pyasic calls against these miners can take 24–30s and time out while the event loop is saturated — `_preset_map` stays empty and is never retried. The select then stays `unavailable` until the next manual HA restart (which is exactly what I hit; a restart fixed it immediately, with the endpoint returning all presets as normal).

## Change

Retry the preset fetch on later coordinator updates while `_preset_map` is still empty, guarded by an `_fetch_in_progress` flag so retries don't pile up and stop once the list is filled. No behaviour change once the presets are loaded.

Closes #33.

## Note

I'm running this on my own installation and want to watch it for a few more days before it gets merged — please hold until I confirm it's stable.
