### PR TITLE
Add VNish mining throttle control (number entity, 20-100%) - closes #20

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -559,8 +559,9 @@ async def _set_vnish_throttle(ip: str, percent: int, password: str = "admin") ->
     """Set the mining throttle level on a VNish miner (VNish >= 1.3.3).
 
     percent is the target power level in percent of full power (e.g. 50 cuts
-    hashrate roughly in half without stopping the miner). Follows the
-    mining/* command family (pause/resume/stop/start).
+    hashrate roughly in half without stopping the miner). Endpoint and payload
+    match what the VNish web UI itself calls (POST /mining/throttle with
+    {"percent": N}); verified live against an S19 Pro Hydro on VNish 1.3.3.
     """
     import aiohttp
 

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -61,6 +61,8 @@ DEFAULT_DATA = {
     "vnish_preset": None,
     "vnish_best_share": None,
     "vnish_found_blocks": None,
+    "vnish_throttle": None,
+    "vnish_miner_state": None,
     "vnish_voltage": None,
     "vnish_freq": None,
     "vnish_min_voltage": None,
@@ -300,6 +302,14 @@ async def _fetch_vnish_summary(ip: str, password: str = "admin") -> dict | None:
                         result["best_share"] = int(miner_data["best_share"])
                     if "found_blocks" in miner_data:
                         result["found_blocks"] = int(miner_data["found_blocks"])
+                    # VNish >= 1.3.3: miner_status carries the throttle level
+                    # (percent of full power, e.g. 100 = unthrottled) and the
+                    # miner state (mining/paused/stopped/...).
+                    status = miner_data.get("miner_status") or {}
+                    if "throttled" in status:
+                        result["throttled"] = status.get("throttled")
+                    if "miner_state" in status:
+                        result["miner_state"] = status.get("miner_state")
                 return result if result else None
     except Exception as e:
         _LOGGER.debug("Failed to fetch VNish summary: %s", e)
@@ -542,6 +552,52 @@ async def _set_vnish_overclock(
                 return success
     except Exception as e:
         _LOGGER.debug("VNish %s: failed to set overclock: %s", ip, e)
+    return False
+
+
+async def _set_vnish_throttle(ip: str, percent: int, password: str = "admin") -> bool:
+    """Set the mining throttle level on a VNish miner (VNish >= 1.3.3).
+
+    percent is the target power level in percent of full power (e.g. 50 cuts
+    hashrate roughly in half without stopping the miner). Follows the
+    mining/* command family (pause/resume/stop/start).
+    """
+    import aiohttp
+
+    base_url = f"http://{ip}/api/v1"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{base_url}/unlock",
+                json={"pw": password},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug("VNish %s: unlock failed: %s", ip, resp.status)
+                    return False
+                token = (await resp.json()).get("token")
+                if not token:
+                    return False
+
+            async with session.post(
+                f"{base_url}/mining/throttle",
+                headers={"Authorization": token},
+                json={"percent": int(percent)},
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                success = resp.status == 200
+                _LOGGER.debug(
+                    "VNish %s: POST /mining/throttle percent=%s status=%s",
+                    ip, percent, resp.status,
+                )
+                if not success:
+                    _LOGGER.warning(
+                        "VNish %s: throttle to %s%% failed (HTTP %s)",
+                        ip, percent, resp.status,
+                    )
+                return success
+    except Exception as e:
+        _LOGGER.debug("VNish %s: failed to set throttle: %s", ip, e)
     return False
 
 
@@ -1262,6 +1318,8 @@ class MinerCoordinator(DataUpdateCoordinator):
             "vnish_preset": None,
             "vnish_best_share": None,
             "vnish_found_blocks": None,
+            "vnish_throttle": None,
+            "vnish_miner_state": None,
             "vnish_voltage": None,
             "vnish_freq": None,
             "vnish_min_voltage": None,
@@ -1318,6 +1376,8 @@ class MinerCoordinator(DataUpdateCoordinator):
             if vnish_summary:
                 data["vnish_best_share"] = vnish_summary.get("best_share")
                 data["vnish_found_blocks"] = vnish_summary.get("found_blocks")
+                data["vnish_throttle"] = vnish_summary.get("throttled")
+                data["vnish_miner_state"] = vnish_summary.get("miner_state")
 
             # Fetch VNish overclock limits (no auth required)
             vnish_limits = await _fetch_vnish_overclock_limits(self.miner.ip)

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -87,13 +87,20 @@ async def async_setup_entry(
     # Add VNish voltage and frequency number entities
     fw_ver = coordinator.data.get("fw_ver", "") or ""
     if _is_vnish_miner(coordinator.miner, fw_ver):
-        async_add_entities(
-            [
-                VNishVoltageNumber(coordinator=coordinator),
-                VNishFrequencyNumber(coordinator=coordinator),
-                VNishThrottleNumber(coordinator=coordinator),
-            ]
-        )
+        vnish_entities = [
+            VNishVoltageNumber(coordinator=coordinator),
+            VNishFrequencyNumber(coordinator=coordinator),
+        ]
+        # The throttle command only exists on newer VNish firmware (>= 1.3.3).
+        # Only create the entity when the firmware actually reports a throttle
+        # level (or the cached device profile recorded one while the miner was
+        # last online), instead of leaving a permanently unavailable control
+        # on older firmware.
+        if (coordinator.data or {}).get("vnish_throttle") is not None or getattr(
+            coordinator, "cached_profile", {}
+        ).get("has_throttle", False):
+            vnish_entities.append(VNishThrottleNumber(coordinator=coordinator))
+        async_add_entities(vnish_entities)
 
 
 class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -751,8 +751,13 @@ class VNishThrottleNumber(_VNishOverclockBase):
 
     @property
     def native_step(self) -> float:
-        """Return step size."""
-        return 1
+        """Return step size.
+
+        5%-steps keep the slider pleasant to use; the step only constrains
+        the UI - service calls (automations/power managers) can still set
+        any integer percent within the 20-100 range.
+        """
+        return 5
 
     @property
     def icon(self) -> str:

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -29,6 +29,7 @@ from .coordinator import (
     _is_bos_miner,
     _is_vnish_miner,
     _set_vnish_overclock,
+    _set_vnish_throttle,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,6 +91,7 @@ async def async_setup_entry(
             [
                 VNishVoltageNumber(coordinator=coordinator),
                 VNishFrequencyNumber(coordinator=coordinator),
+                VNishThrottleNumber(coordinator=coordinator),
             ]
         )
 
@@ -711,6 +713,61 @@ class VNishFrequencyNumber(_VNishOverclockBase):
         if not success:
             _LOGGER.error(
                 "%s: failed to set VNish frequency to %s MHz",
+                self.coordinator.config_entry.title, value
+            )
+        await self.coordinator.async_request_refresh()
+
+
+class VNishThrottleNumber(_VNishOverclockBase):
+    """Number entity for the VNish mining throttle (percent of full power).
+
+    VNish >= 1.3.3 can throttle the miner like a dimmer (issue #20): e.g. 50%
+    roughly halves hashrate/power draw without stopping the miner - useful for
+    surplus-PV power management or using the miner as an adjustable heater.
+    """
+
+    _data_key = "vnish_throttle"
+    # min/max are fixed by the firmware's supported throttle range, not
+    # delivered via the API like the overclock limits.
+    _min_key = "vnish_throttle_min"
+    _max_key = "vnish_throttle_max"
+    _default_min = 20
+    _default_max = 100
+
+    @property
+    def name(self) -> str:
+        """Return entity name."""
+        return f"{self.coordinator.config_entry.title} Throttle"
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique entity id."""
+        return f"{self.coordinator.config_entry.entry_id}-vnish-throttle"
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Return unit of measurement."""
+        return "%"
+
+    @property
+    def native_step(self) -> float:
+        """Return step size."""
+        return 1
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:car-speed-limiter"
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new throttle level."""
+        password = self._get_password()
+        success = await _set_vnish_throttle(
+            self.coordinator.data["ip"], percent=int(value), password=password
+        )
+        if not success:
+            _LOGGER.error(
+                "%s: failed to set VNish throttle to %s%%",
                 self.coordinator.config_entry.title, value
             )
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## What

VNish >= 1.3.3 can throttle the miner like a dimmer (#20): e.g. 50% roughly halves hashrate/power draw without stopping the miner. Useful for thermostat-style heating control (the original request) and for PV-surplus power management.

- **coordinator**: reads `miner_status.throttled` and `miner_status.miner_state` from the VNish summary into `vnish_throttle` / `vnish_miner_state`
- **number**: new `VNishThrottleNumber` (20-100%, step 1) on VNish devices, writes via `POST /api/v1/mining/throttle` with `{"percent": N}`

## Verification

- Endpoint/payload match what the VNish web UI itself calls (checked the UI bundle: `post("/mining/throttle", {percent: O})`)
- Live-tested end-to-end on my S19 Pro Hydro (VNish 1.3.3): HA slider 100 → 90 → miner reports `throttled: 90` and reduces accordingly, back to 100 cleanly. Read side updates on every poll.
- Failure-safe: if the firmware doesn't support throttle (pre-1.3.3), the POST fails, a warning is logged and the slider snaps back to the real value on the next poll.

## Status

Running on my production instance now. As with #29-#31 I'll observe it a few days before merging.