### PR TITLE
Fix offline coordinator: start polling loop when miner is unreachable at startup

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -148,8 +148,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             miner_ip,
         )
         m_coordinator.prime_from_cached_profile()
-    else:
-        await m_coordinator.async_config_entry_first_refresh()
+    # Always start the polling loop — when offline, _async_update_data returns
+    # the primed data without raising UpdateFailed, so this completes normally
+    # and schedules the background refresh that will detect the miner once it
+    # comes back online.
+    await m_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 


### PR DESCRIPTION
## Problem

When a miner is powered off at HA startup, `async_setup_entry` calls `prime_from_cached_profile()` and then skips `async_config_entry_first_refresh()` (it was in the `else` branch). The `DataUpdateCoordinator` polling loop therefore never started.

**Symptom:** Entities showed `unavailable` immediately after HA restart (correct), but they never recovered — even after the miner came back online. The entity `last_reported` timestamp stayed frozen at the HA restart time forever. The coordinator simply never polled.

**Root cause:**  
`DataUpdateCoordinator` needs `async_config_entry_first_refresh()` (or an equivalent `async_refresh()` call) to start its internal scheduling loop. Skipping it in the offline path meant no periodic refresh ever ran.

## Fix

Move `async_config_entry_first_refresh()` outside the `if/else` so it is always called, regardless of whether the miner was reachable at startup.

When the miner is offline, `_async_update_data()` returns the primed data without raising `UpdateFailed` (the `_primed_offline` branch), so `async_config_entry_first_refresh()` completes successfully and starts the scheduler. The miner is detected on the next poll cycle once it comes back online and entities recover automatically.

## Testing

- Start HA with the miner **off** → integration loads, entities show `unavailable`, `last_reported` updates every poll interval
- Power the miner **on** → within 60 s the coordinator detects it, entities become available with live values  
- Normal startup (miner **on**) → unchanged behaviour