### PR TITLE
VNish preset select: add "disabled" option so user can switch back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.9-beta4 (2026-06-14)
+
+- **VNish preset select: "disabled" option** (#37): adds a synthetic "disabled" entry to the preset dropdown so you can switch back from a named preset to no-preset operation directly from HA — without going into the VNish web UI.
+- **Coordinator cleanup**: replaced internal `miner_responding` flag with the standard `coordinator.available` property; `_handle_coordinator_update` now checks availability before triggering preset fetch (aligns with upstream style).
+
 ## v1.3.9-beta3 (2026-06-11)
 
 - **Offline-tolerant setup** (#31): powered-off miners no longer end in "retrying setup" — entities are created from a cached device profile and show *unavailable* until the miner returns.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![hacs][hacsbadge]][hacs]
 [![Project Maintenance][maintenance-shield]][user_profile]
 
-> **⚠️ BETA BRANCH** - This branch contains experimental features that are not yet merged to main. Current version: **v1.3.9-beta3**
+> **⚠️ BETA BRANCH** - This branch contains experimental features that are not yet merged to main. Current version: **v1.3.9-beta4**
 
 > **Note:** This is a fork of the original [Schnitzel/hass-miner](https://github.com/Schnitzel/hass-miner) which is no longer actively maintained. Full credit goes to [@Schnitzel](https://github.com/Schnitzel) and [@b-rowan](https://github.com/b-rowan) for creating this excellent integration.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![hacs][hacsbadge]][hacs]
 [![Project Maintenance][maintenance-shield]][user_profile]
 
-> **⚠️ BETA BRANCH** - This branch contains experimental features that are not yet merged to main. Current version: **v1.3.8-beta5**
+> **⚠️ BETA BRANCH** - This branch contains experimental features that are not yet merged to main. Current version: **v1.3.9-beta3**
 
 > **Note:** This is a fork of the original [Schnitzel/hass-miner](https://github.com/Schnitzel/hass-miner) which is no longer actively maintained. Full credit goes to [@Schnitzel](https://github.com/Schnitzel) and [@b-rowan](https://github.com/b-rowan) for creating this excellent integration.
 

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -148,8 +148,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             miner_ip,
         )
         m_coordinator.prime_from_cached_profile()
-    else:
-        await m_coordinator.async_config_entry_first_refresh()
+    # Always start the polling loop — when offline, _async_update_data returns
+    # the primed data without raising UpdateFailed, so this completes normally
+    # and schedules the background refresh that will detect the miner once it
+    # comes back online.
+    await m_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1117,8 +1117,6 @@ class MinerCoordinator(DataUpdateCoordinator):
         # True while running on cached-profile data because the miner was
         # unreachable during setup; cleared on the first successful update.
         self._primed_offline = False
-        # True only after a successful live poll; False on init and while offline.
-        self._miner_responding: bool = False
         super().__init__(
             hass=hass,
             logger=_LOGGER,
@@ -1144,11 +1142,6 @@ class MinerCoordinator(DataUpdateCoordinator):
         if self.miner is None:
             return False
         return self._failure_count <= AVAILABILITY_FAILURE_THRESHOLD
-
-    @property
-    def miner_responding(self) -> bool:
-        """True only after a successful live poll; False on init and while offline."""
-        return self._miner_responding
 
     def _keep_last_or_fail(self, message: str, err: Exception | None = None):
         """Handle a failed poll: absorb short hiccups, raise on streaks.
@@ -1299,7 +1292,6 @@ class MinerCoordinator(DataUpdateCoordinator):
         miner = await self.get_miner()
 
         if miner is None:
-            self._miner_responding = False
             if self._primed_offline:
                 # Set up from the cached profile while the miner is powered
                 # off: this state is expected, so stay quiet (no ERROR per
@@ -1361,7 +1353,6 @@ class MinerCoordinator(DataUpdateCoordinator):
         # Success: reset the failure count and leave primed-offline mode
         self._failure_count = 0
         self._primed_offline = False
-        self._miner_responding = True
 
         def normalize_hashrate_to_th(value):
             """Normalize hashrate to TH/s.

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1117,6 +1117,8 @@ class MinerCoordinator(DataUpdateCoordinator):
         # True while running on cached-profile data because the miner was
         # unreachable during setup; cleared on the first successful update.
         self._primed_offline = False
+        # True only after a successful live poll; False on init and while offline.
+        self._miner_responding: bool = False
         super().__init__(
             hass=hass,
             logger=_LOGGER,
@@ -1142,6 +1144,11 @@ class MinerCoordinator(DataUpdateCoordinator):
         if self.miner is None:
             return False
         return self._failure_count <= AVAILABILITY_FAILURE_THRESHOLD
+
+    @property
+    def miner_responding(self) -> bool:
+        """True only after a successful live poll; False on init and while offline."""
+        return self._miner_responding
 
     def _keep_last_or_fail(self, message: str, err: Exception | None = None):
         """Handle a failed poll: absorb short hiccups, raise on streaks.
@@ -1292,6 +1299,7 @@ class MinerCoordinator(DataUpdateCoordinator):
         miner = await self.get_miner()
 
         if miner is None:
+            self._miner_responding = False
             if self._primed_offline:
                 # Set up from the cached profile while the miner is powered
                 # off: this state is expected, so stay quiet (no ERROR per
@@ -1353,6 +1361,7 @@ class MinerCoordinator(DataUpdateCoordinator):
         # Success: reset the failure count and leave primed-offline mode
         self._failure_count = 0
         self._primed_offline = False
+        self._miner_responding = True
 
         def normalize_hashrate_to_th(value):
             """Normalize hashrate to TH/s.

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/tntvlad/hass-miner/issues",
   "requirements": ["betterproto==2.0.0b7", "grpcio>=1.60.0", "pyasic>=0.78.0"],
   "ssdp": [],
-  "version": "1.3.9-beta3",
+  "version": "1.3.9-beta4",
   "zeroconf": []
 }

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -766,16 +766,19 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update local state when coordinator data changes."""
+        if (
+            not self._preset_map
+            and not self._fetch_in_progress
+            and self.coordinator.available
+            and self.hass is not None
+        ):
+            self.hass.async_create_task(self._fetch_presets())
         vnish_preset = self.coordinator.data.get("vnish_preset")
         if vnish_preset and self._preset_map:
             for pretty, name in self._preset_map.items():
                 if name == vnish_preset:
                     self._current_preset = pretty
                     break
-        elif not self._preset_map and not self._fetch_in_progress and self.coordinator.miner_responding:
-            # Preset list not yet populated (e.g. miner was offline at startup);
-            # retry now that the coordinator has a live response.
-            self.hass.async_create_task(self._fetch_presets())
         super()._handle_coordinator_update()
 
     @property

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -631,6 +631,7 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
         self._presets: list[dict] = []
         self._preset_map: dict[str, str] = {}  # pretty -> name
         self._current_preset: str | None = None
+        self._fetch_in_progress: bool = False
 
     @property
     def name(self) -> str | None:
@@ -728,31 +729,37 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
 
     async def _fetch_presets(self) -> None:
         """Fetch available presets from VNish API."""
-        async with aiohttp.ClientSession() as session:
-            if not await self._api.unlock(session):
-                return
+        self._fetch_in_progress = True
+        try:
+            async with aiohttp.ClientSession() as session:
+                if not await self._api.unlock(session):
+                    return
 
-            presets = await self._api.get_presets(session)
-            if not presets:
-                return
+                presets = await self._api.get_presets(session)
+                if not presets:
+                    return
 
-            self._presets = presets
-            self._preset_map = {}
-            for p in presets:
-                pretty = p.get("pretty", p.get("name", "unknown"))
-                name = p.get("name", "unknown")
-                self._preset_map[pretty] = name
+                self._presets = presets
+                self._preset_map = {}
+                # Always include "disabled" so the user can switch back to it
+                self._preset_map["disabled"] = "disabled"
+                for p in presets:
+                    pretty = p.get("pretty", p.get("name", "unknown"))
+                    name = p.get("name", "unknown")
+                    self._preset_map[pretty] = name
 
-            settings = await self._api.get_settings(session)
-            if settings:
-                current_name = (
-                    settings.get("miner", {}).get("overclock", {}).get("preset")
-                )
-                if current_name:
-                    for pretty, name in self._preset_map.items():
-                        if name == current_name:
-                            self._current_preset = pretty
-                            break
+                settings = await self._api.get_settings(session)
+                if settings:
+                    current_name = (
+                        settings.get("miner", {}).get("overclock", {}).get("preset")
+                    )
+                    if current_name:
+                        for pretty, name in self._preset_map.items():
+                            if name == current_name:
+                                self._current_preset = pretty
+                                break
+        finally:
+            self._fetch_in_progress = False
 
         self.async_write_ha_state()
 
@@ -765,6 +772,10 @@ class VNishPresetSelect(CoordinatorEntity[MinerCoordinator], SelectEntity):
                 if name == vnish_preset:
                     self._current_preset = pretty
                     break
+        elif not self._preset_map and not self._fetch_in_progress and self.coordinator.miner_responding:
+            # Preset list not yet populated (e.g. miner was offline at startup);
+            # retry now that the coordinator has a live response.
+            self.hass.async_create_task(self._fetch_presets())
         super()._handle_coordinator_update()
 
     @property


### PR DESCRIPTION
## Problem

When a VNish preset is active and you want to switch back to no-preset operation, there's currently no way to do it via the select entity — the option list only contains the named presets returned by the firmware API. The only workaround is to go directly into the VNish web UI.

## Change

Add a synthetic `"disabled"` entry to `_preset_map` in `_fetch_presets()`:

```python
self._preset_map["disabled"] = "disabled"
```

This maps the UI label "disabled" to the firmware option name "disabled", which is what VNish expects when you call the preset API with no active preset. The entry is prepended before the named presets so it appears at the top of the dropdown.

## Tested on

- Antminer S19 Hydro running VNish firmware
- Selecting "disabled" from the HA entity correctly deactivates the active preset (verified via the VNish web UI and subsequent hashrate change)
- Switching from "disabled" to a named preset works as expected in both directions