### PR TITLE
Coordinator: retry without CONFIG on any first-attempt failure (fix sensor freeze)

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1329,10 +1329,18 @@ class MinerCoordinator(DataUpdateCoordinator):
         try:
             miner_data = await self.miner.get_data(include=data_options)
         except Exception as err:
-            # VNish firmware has a bug with CONFIG - retry without it
-            if "config" in str(err).lower():
+            # VNish's CONFIG fetch (settings/presets endpoints) is flaky and can
+            # fail with errors that don't mention "config" - e.g. "HTTP error
+            # sending 'settings'", or an AttributeError when the presets endpoint
+            # returns a list instead of a dict. CONFIG only feeds the optional
+            # active_preset_name/config sensors, so on ANY first-attempt failure
+            # retry once WITHOUT CONFIG before giving up. Otherwise a transient
+            # settings/presets hiccup fails the whole poll and freezes ALL sensors
+            # (including the hashboard count) at last-known-good until a manual
+            # reload - which is how a 4-board hydro can lose a board for hours.
+            if pyasic.DataOptions.CONFIG in data_options:
                 _LOGGER.warning(
-                    f"Config fetch failed for {self.miner}, retrying without CONFIG: {err}"
+                    f"get_data failed for {self.miner}, retrying without CONFIG: {err}"
                 )
                 data_options.remove(pyasic.DataOptions.CONFIG)
                 try:

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/tntvlad/hass-miner/issues",
   "requirements": ["betterproto==2.0.0b7", "grpcio>=1.60.0", "pyasic>=0.78.0"],
   "ssdp": [],
-  "version": "1.3.9-beta6",
+  "version": "1.3.9-beta7",
   "zeroconf": []
 }


### PR DESCRIPTION
## Problem

On VNish miners the coordinator fetches `CONFIG` (the `settings`/`presets`/`perf_summary` endpoints) on every poll. On slow miners those calls are flaky and can fail with errors that don't contain the word "config" — e.g. `HTTP error sending 'settings'`, or an `AttributeError` when the presets endpoint returns a list instead of a dict.

The retry-without-CONFIG path only fired when the error string contained `"config"`. So those failures fell through to `_keep_last_or_fail`, which freezes **all** sensors at last-known-good — including the hashboard count. On a 4-board hydro this dropped board #3 for hours even though the hardware was healthy (all 4 chains mining); it only recovered on a manual reload.

## Fix

Guard the retry on `pyasic.DataOptions.CONFIG in data_options` instead of the error text, so **any** first-attempt failure retries once without the optional CONFIG fetch before giving up. CONFIG only feeds the optional `active_preset_name`/config sensors, so the critical data (hashboards, hashrate, temperatures) always gets through on a flaky cycle.

## Notes

- Manifest bumped to `1.3.9-beta7`.
- Diagnosed on a live S19 Pro Hydro (VNish 1.3.3): the VNish `/summary` returns all 4 chains and pyasic `HASHBOARDS` returns all 4 boards — the board loss was purely the poll-freeze, not the data source.
